### PR TITLE
Add a quick check to see if the parsing is necessary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -334,7 +334,10 @@ function initialSetup() {
 
 			logger(`Received JSON object: ${obj}`); //To make it easier for devs to verify the JSON objects they're sending
 
-			obj = JSON.parse(String(obj)); //Re-parse JSON
+			if(typeof obj !== 'object' && obj !== null) {
+				logger(`Received JSON object: ${obj}`, 'info-quiet');
+				obj = JSON.parse(String(obj)); //Re-parse JSON
+			}
 
 			let deviceId = obj.deviceId;
 			let device = GetDeviceByDeviceId(deviceId);


### PR DESCRIPTION
This would check and make sure that you're not reparsing a already parsed json object. I think the issue may just be the way that C# likes to send json objects. From my experiences, C# like to stringify any json objects you send.
